### PR TITLE
Fix link to "records"

### DIFF
--- a/site/design-notes/patterns/pattern-match-object-model.md
+++ b/site/design-notes/patterns/pattern-match-object-model.md
@@ -729,4 +729,4 @@ APIs, this may be a perfectly sensible move.
 [patternmatch]: pattern-matching-for-java.html
 [patternsem]: pattern-match-semantics.html
 [gof]: https://en.wikipedia.org/wiki/Design_Patterns
-[records]: records-and-sealed-classes.html
+[records]: ../records-and-sealed-classes.html


### PR DESCRIPTION
This commit fixes the link to "records" by referencing `records-and-sealed-classes.html` in the parent folder.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Errors
&nbsp;⚠️ Executable files are not allowed (file: site/design-notes/patterns/pattern-match-object-model.md)
&nbsp;⚠️ OCA signatory status must be verified

### Reviewers
 * [Brian Goetz](https://openjdk.java.net/census#briangoetz) (@briangoetz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/amber-docs pull/7/head:pull/7` \
`$ git checkout pull/7`

Update a local copy of the PR: \
`$ git checkout pull/7` \
`$ git pull https://git.openjdk.java.net/amber-docs pull/7/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7`

View PR using the GUI difftool: \
`$ git pr show -t 7`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/amber-docs/pull/7.diff">https://git.openjdk.java.net/amber-docs/pull/7.diff</a>

</details>
