### PR TITLE
Fix typos in pattern-match-object-model.md

### DIFF
--- a/site/design-notes/patterns/pattern-match-object-model.md
+++ b/site/design-notes/patterns/pattern-match-object-model.md
@@ -87,7 +87,7 @@ this missing ability to recover the specific from the abstract more directly.
 
 Java provides direct linguistic support for aggregation, in the form of
 _constructors_ that take a description of an object's initial state and
-aggregates it into an instance, but does not directly provided the reverse.
+aggregate it into an instance, but does not directly provide the reverse.
 Instead, we leave that problem to APIs, which may expose accessors for
 individual state components, and those accessors may or may not map to the
 arguments presented to constructors or factories.  But this is a poor
@@ -96,7 +96,7 @@ and for destructuring often operate at different levels of granularity, and look
 structurally different -- and these differences provide places for bugs to hide.
 Whatever tools the language offers us for aggregation (e.g., constructors,
 factories, builders), it should also offer us complementary destructuring,
-ideally that is syntactically similar in declaration and use, and operate at the
+ideally that is syntactically similar in declaration and use, and operates at the
 same level of abstraction.  For example, if our `Shape` library provided
 factories like the above, it could provide destructuring patterns that are
 similar in name and structure:
@@ -240,7 +240,7 @@ be handled as a nested _constant pattern_, should we decide to support them.
 This might look like (illustrative syntax only):
 
 ```
-if (os instanceof Optional.of(Shape.ofRedBall(== 1))) { ... }
+if (os instanceof Optional.of(Shape.redBall(== 1))) { ... }
 ```
 
 where `== c` is a constant pattern that matches the constant `c`.  


### PR DESCRIPTION
This commit fixes a few minor typos in `pattern-match-object-model.md`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Brian Goetz](https://openjdk.java.net/census#briangoetz) (@briangoetz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/amber-docs pull/8/head:pull/8` \
`$ git checkout pull/8`

Update a local copy of the PR: \
`$ git checkout pull/8` \
`$ git pull https://git.openjdk.java.net/amber-docs pull/8/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8`

View PR using the GUI difftool: \
`$ git pr show -t 8`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/amber-docs/pull/8.diff">https://git.openjdk.java.net/amber-docs/pull/8.diff</a>

</details>
