### PR TITLE
Fixing bug in _index.md

### DIFF
--- a/site/_index.md
+++ b/site/_index.md
@@ -73,8 +73,7 @@ Withdrawn:
       - [Pattern Matching for Java -- Runtime and Translation](design-notes/patterns/pattern-match-translation) (June 2017)
       - [Extending `switch` for Pattern Matching](design-notes/patterns/extending-switch-for-patterns) (April 2017)
       - [Type Patterns in
-        `switch`](design-notes/patterns/type-patterns-in-switch) (September
-        2020)
+        `switch`](design-notes/patterns/type-patterns-in-switch) (September 2020)
       - [Patterns: Exhaustiveness, Unconditionality, and
         Remainder](design-notes/patterns/exhaustiveness) (May 2023)
     - [String Tapas Redux: Beyond Mere String Interpolation](design-notes/templated-strings) (September 2021)


### PR DESCRIPTION
Since "2020)" was on its own separate line, markdown interpreted it as a start of an ordered list. Just like this.

1\)
2\)
3\)

And then when that markdown got converted to HTML, it got converted into a literal \<ol\> tag, which stands for Ordered List - http://html5doctor.com/element-index/#ol

However, in order for an Ordered List to show anything, it must have within it an \<li\> tag, which stands for List Item. Since there is no such tag, HTML treats this as an empty list and shows nothing, resulting in the bug.

Here is a snippet from the literal HTML from this link -- https://openjdk.org/projects/amber/

```
<li>
    <a href="design-notes/patterns/type-patterns-in-switch">Type Patterns in <code>switch</code></a> (September 
    <ol type="1" start="2020"></ol>
</li>
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/amber-docs.git pull/19/head:pull/19` \
`$ git checkout pull/19`

Update a local copy of the PR: \
`$ git checkout pull/19` \
`$ git pull https://git.openjdk.org/amber-docs.git pull/19/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19`

View PR using the GUI difftool: \
`$ git pr show -t 19`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/amber-docs/pull/19.diff">https://git.openjdk.org/amber-docs/pull/19.diff</a>

</details>
