### PR TITLE
Fixing the incorrect code example

### DIFF
--- a/site/design-notes/patterns/towards-member-patterns.md
+++ b/site/design-notes/patterns/towards-member-patterns.md
@@ -337,7 +337,7 @@ public inverse String match(String... groups) {
     Matcher m = matcher(that);    // *that* is the match candidate
     if (m.matches())              // receiver for matcher() is the Pattern
         __yield IntStream.range(1, m.groupCount())
-                            .map(Matcher::group)
+                            .map(m::group)
                             .toArray(String[]::new);
 }
 ```


### PR DESCRIPTION
There are only 3 methods on java.util.regex.Matcher that have the name group. Here they are.

https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/regex/Matcher.html#group()

https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/regex/Matcher.html#group(int)

https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/regex/Matcher.html#group(java.lang.String)

And since this is an IntStream, the only possible method that could be matched is the 2nd link above. Based on that, it is clear that the code example meant to put an `m` instead of `Matcher`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/amber-docs.git pull/23/head:pull/23` \
`$ git checkout pull/23`

Update a local copy of the PR: \
`$ git checkout pull/23` \
`$ git pull https://git.openjdk.org/amber-docs.git pull/23/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23`

View PR using the GUI difftool: \
`$ git pr show -t 23`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/amber-docs/pull/23.diff">https://git.openjdk.org/amber-docs/pull/23.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/amber-docs/pull/23#issuecomment-1912344190)