### PR TITLE
Reorder docs latest first - on home page

### DIFF
--- a/site/_index.md
+++ b/site/_index.md
@@ -60,28 +60,29 @@ Withdrawn:
 ## Documents
 
 -   Guides
-    -   [Local Variable Type Inference Style Guide](guides/lvti-style-guide) (March 2018)
-    -   [Local Variable Type Inference FAQ](guides/lvti-faq) (Oct 2018)
     -   [Programmer's Guide to Text Blocks](guides/text-blocks-guide) (Aug 2019)
+    -   [Local Variable Type Inference FAQ](guides/lvti-faq) (Oct 2018)  
+    - [Local Variable Type Inference Style Guide](guides/lvti-style-guide) (March 2018)
 
 -   Design notes
-    -   [Symbolic References for Constants](design-notes/constables) (March 2018)
+    -   [String Tapas Redux: Beyond Mere String Interpolation](design-notes/templated-strings) (September 2021)
+    -   [Towards Better Serialization](design-notes/towards-better-serialization) (June 2019) 
     -   [Data Classes and Sealed Types for Java](design-notes/records-and-sealed-classes) (February 2019)
-    -   [Towards Better Serialization](design-notes/towards-better-serialization) (June 2019)
+    -   [Symbolic References for Constants](design-notes/constables) (March 2018)
     -   Pattern matching
-        -   [Pattern Matching for Java](design-notes/patterns/pattern-matching-for-java) (September 2018)
+        -   [Towards Member Patterns](design-notes/patterns/towards-member-patterns) (January 2024)
+        -   [Patterns: Exhaustiveness, Unconditionality, and Remainder](design-notes/patterns/exhaustiveness) (May 2023)
         -   [Pattern Matching in the Java Object Model](design-notes/patterns/pattern-match-object-model) (December 2020)
+        -   [Type Patterns in `switch`](design-notes/patterns/type-patterns-in-switch) (September 2020)
         -   [Pattern Matching for Java -- Semantics](design-notes/patterns/pattern-match-semantics) (August 2020)
+        -   [Pattern Matching for Java](design-notes/patterns/pattern-matching-for-java) (September 2018)
         -   [Pattern Matching for Java -- Runtime and Translation](design-notes/patterns/pattern-match-translation) (June 2017)
         -   [Extending `switch` for Pattern Matching](design-notes/patterns/extending-switch-for-patterns) (April 2017)
-        -   [Type Patterns in `switch`](design-notes/patterns/type-patterns-in-switch) (September 2020)
-        -   [Patterns: Exhaustiveness, Unconditionality, and Remainder](design-notes/patterns/exhaustiveness) (May 2023)
-        -   [Towards Member Patterns](design-notes/patterns/towards-member-patterns) (January 2024)
-    -   [String Tapas Redux: Beyond Mere String Interpolation](design-notes/templated-strings) (September 2021)
 
 -   Historical notes
-    -   [Data Classes for Java](design-notes/data-classes-historical-1) (October 2017)
     -   [Data Classes for Java](design-notes/data-classes-historical-2) (February 2018)
+    -   [Data Classes for Java](design-notes/data-classes-historical-1) (October 2017)
+    
 
 ## Community
 

--- a/site/_index.md
+++ b/site/_index.md
@@ -62,7 +62,7 @@ Withdrawn:
 -   Guides
     -   [Programmer's Guide to Text Blocks](guides/text-blocks-guide) (Aug 2019)
     -   [Local Variable Type Inference FAQ](guides/lvti-faq) (Oct 2018)  
-    - [Local Variable Type Inference Style Guide](guides/lvti-style-guide) (March 2018)
+    -   [Local Variable Type Inference Style Guide](guides/lvti-style-guide) (March 2018)
 
 -   Design notes
     -   [String Tapas Redux: Beyond Mere String Interpolation](design-notes/templated-strings) (September 2021)


### PR DESCRIPTION
As of now on the home page https://openjdk.org/projects/amber/ , Documents section lists are mostly ordered as oldest-latest month-year.
It would be best to have them as Latest-On-Top.
Other OpenJDK projects like https://openjdk.org/projects/babylon/ use the same approach.

[x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Errors
&nbsp;⚠️ OCA signatory status must be verified
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/amber-docs.git pull/31/head:pull/31` \
`$ git checkout pull/31`

Update a local copy of the PR: \
`$ git checkout pull/31` \
`$ git pull https://git.openjdk.org/amber-docs.git pull/31/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31`

View PR using the GUI difftool: \
`$ git pr show -t 31`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/amber-docs/pull/31.diff">https://git.openjdk.org/amber-docs/pull/31.diff</a>

</details>
